### PR TITLE
Removing the master-slave words

### DIFF
--- a/silesiasolar_backend/influx_updater/modbus_client.py
+++ b/silesiasolar_backend/influx_updater/modbus_client.py
@@ -5,10 +5,10 @@ import numpy as np
 
 class ModbusClient(ModbusTcpClient):
 
-    def __init__(self, host, port, slave_address):
+    def __init__(self, host, port, subordinate_address):
         self.host = host
         self.port = port
-        self.slave_address = slave_address
+        self.subordinate_address = subordinate_address
         ModbusTcpClient.__init__(self, host=host, port=port)
         if not self.connect():
             raise ConnectionError('Cannot connect to {0}:{1}'.format(host, port))
@@ -37,14 +37,14 @@ class ModbusClient(ModbusTcpClient):
             raise UnknownDatatypeException('Unknown data type with id: {0}'.format(data_type))
 
         if function_code == FunctionCodes.READ_INPUT_REGISTERS:
-            response = self.read_input_registers(address=register_address, count=bytes_count, unit=self.slave_address)
+            response = self.read_input_registers(address=register_address, count=bytes_count, unit=self.subordinate_address)
         elif function_code == FunctionCodes.READ_HOLDING_REGISTERS:
-            response = self.read_input_registers(address=register_address, count=bytes_count, unit=self.slave_address)
+            response = self.read_input_registers(address=register_address, count=bytes_count, unit=self.subordinate_address)
         else:
             raise UnknownFunctioncodeException('Unknown function code: {0}'.format(function_code))
 
         if response.isError():
-            raise ReadError('Cannot get value from register: {0}, slave_address: {1}'.format(register_address, self.slave_address))
+            raise ReadError('Cannot get value from register: {0}, subordinate_address: {1}'.format(register_address, self.subordinate_address))
 
         return self.convert(response.registers, data_type)
 

--- a/silesiasolar_backend/influx_updater/utils.py
+++ b/silesiasolar_backend/influx_updater/utils.py
@@ -60,7 +60,7 @@ def update_influx():
 
     for host in hosts:
         try:
-            modbus_client = ModbusClient(host=host.ip, port=host.port, slave_address=host.slave_address)
+            modbus_client = ModbusClient(host=host.ip, port=host.port, subordinate_address=host.subordinate_address)
         except ConnectionError as exc:
             logger.warning('Cannot connect to host {0}:{1}, skipping...'.format(host.ip, host.port))
             continue

--- a/silesiasolar_backend/management/migrations/0001_initial.py
+++ b/silesiasolar_backend/management/migrations/0001_initial.py
@@ -54,14 +54,14 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('ip', models.CharField(max_length=64)),
                 ('port', models.PositiveIntegerField()),
-                ('slave_address', models.PositiveSmallIntegerField()),
+                ('subordinate_address', models.PositiveSmallIntegerField()),
                 ('description', models.CharField(max_length=128, null=True)),
                 ('location', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='management.Location')),
                 ('meter', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='management.Meter')),
                 ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
             options={
-                'unique_together': {('ip', 'port', 'slave_address')},
+                'unique_together': {('ip', 'port', 'subordinate_address')},
             },
         ),
         migrations.CreateModel(

--- a/silesiasolar_backend/management/models.py
+++ b/silesiasolar_backend/management/models.py
@@ -53,14 +53,14 @@ class Host(models.Model):
 
     ip = models.CharField(max_length=64, null=False)
     port = models.PositiveIntegerField(null=False)
-    slave_address = models.PositiveSmallIntegerField(null=False)
+    subordinate_address = models.PositiveSmallIntegerField(null=False)
     description = models.CharField(max_length=128, null=True)
 
     def __str__(self):
-        return '{0}:{1}:{2}'.format(self.ip, self.port, self.slave_address)
+        return '{0}:{1}:{2}'.format(self.ip, self.port, self.subordinate_address)
 
     class Meta:
-        unique_together = ('ip', 'port', 'slave_address', )
+        unique_together = ('ip', 'port', 'subordinate_address', )
 
 
 class AssignedMeasurement(models.Model):


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.